### PR TITLE
Feat support `Option [T] ? = None`

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -74,7 +74,15 @@ object SwaggerParameterMapper {
       GenSwaggerParameter(parameter.name, referenceType = Some(referenceType))
 
     def optionalParam(optionalTpe: String) = {
-      val asRequired = mapParam(parameter.copy(typeName = optionalTpe), modelQualifier = modelQualifier, customMappings = customMappings)
+      val asRequired = mapParam(parameter.copy(
+        typeName = optionalTpe, 
+        default = parameter.default match {
+          // If `Some("None")`, then `variable: Option[T] ? = None` is specified. So `default` is treated as if it does not exist.
+          case Some("None") => None
+          // Maybe only `None`.
+          case default => default
+        }
+      ), modelQualifier = modelQualifier, customMappings = customMappings)
       asRequired.update(required = false, nullable = true, default = asRequired.default)
     }
 

--- a/core/src/test/resources/students.routes
+++ b/core/src/test/resources/students.routes
@@ -6,7 +6,9 @@
 ###
 GET     /:name    com.iheart.controllers.Students.get(name)
 
-PUT     /defaultValueParam           com.iheart.controllers.DefaultValueParam.put(aFlag:Boolean ?= true)
-PUT     /defaultValueParamString     com.iheart.controllers.DefaultValueParam.put(strFlag:String ?= "defaultValue")
-PUT     /defaultValueParamString3    com.iheart.controllers.DefaultValueParam.put(strFlag:String ?= """defaultValue with triple quotes""")
+PUT     /defaultValueParam                  com.iheart.controllers.DefaultValueParam.put(aFlag:Boolean ?= true)
+PUT     /defaultValueParamString            com.iheart.controllers.DefaultValueParam.put(strFlag:String ?= "defaultValue")
+PUT     /defaultValueParamString3           com.iheart.controllers.DefaultValueParam.put(strFlag:String ?= """defaultValue with triple quotes""")
+PUT     /defaultValueParamOptionalString    com.iheart.controllers.DefaultValueParam.put(optionFlag:Option[String] ?= None)
+PUT     /defaultValueParamOptionalInteger   com.iheart.controllers.DefaultValueParam.put(optionFlag:Option[Int] ?= None)
 

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -146,6 +146,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
       val limitParamJson = (artistJson \ "parameters").as[JsArray].value(1).as[JsObject]
       (limitParamJson \ "name").as[String] === "limit"
       (limitParamJson \ "format").as[String] === "int32"
+      (limitParamJson \ "default").asOpt[String] === None
       (limitParamJson \ "required").as[Boolean] === false
       (limitParamJson \ "x-nullable").as[Boolean] === true
     }
@@ -403,6 +404,56 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
 
       "not set nullable" >> {
         (paramJson \ "x-nullable").isEmpty
+      }
+    }
+
+    "parse param with default None value as optional string field" >> {
+      val endPointJson = (pathJson \ "/api/students/defaultValueParamOptionalString" \ "put").asOpt[JsObject]
+      endPointJson must beSome[JsObject]
+
+      val paramJson: JsValue = parametersOf(endPointJson.get).head
+
+      (paramJson \ "name").as[String] === "optionFlag"
+
+      "set required as false" >> {
+        (paramJson \ "required").as[Boolean] === false
+      }
+
+      "set in as query" >> {
+        (paramJson \ "in").as[String] === "query"
+      }
+
+      "set default value" >> {
+        (paramJson \ "default").asOpt[String] === None
+      }
+
+      "not set nullable" >> {
+        (paramJson \ "x-nullable").as[Boolean]
+      }
+    }
+
+    "parse param with default None value as optional integer field" >> {
+      val endPointJson = (pathJson \ "/api/students/defaultValueParamOptionalInteger" \ "put").asOpt[JsObject]
+      endPointJson must beSome[JsObject]
+
+      val paramJson: JsValue = parametersOf(endPointJson.get).head
+
+      (paramJson \ "name").as[String] === "optionFlag"
+
+      "set required as false" >> {
+        (paramJson \ "required").as[Boolean] === false
+      }
+
+      "set in as query" >> {
+        (paramJson \ "in").as[String] === "query"
+      }
+
+      "set default value" >> {
+        (paramJson \ "default").asOpt[String] === None
+      }
+      
+      "not set nullable" >> {
+        (paramJson \ "x-nullable").as[Boolean]
       }
     }
 


### PR DESCRIPTION
https://github.com/iheartradio/play-swagger/issues/136

# Why do it?

Using `variable: Option[T] ? = None` in the routes file will result in the following error

```
java.lang.IllegalArgumentException: For input string: "None"
```

Such code may be used to simplify redirection calls.

```scala
Redirect(routes.DefaultValueParam.put())
```

# examples

Set up the routes file as follows.

```
PUT /defaultValueParamOptionalString com.iheart.controllers.DefaultValueParam.put(optionFlag:Option[String] ?= None)
```

The generated swagger.json will look like this.

```json
{"operationId":"put","tags":["students"],"parameters":[{"in":"query","name":"optionFlag","type":"string","required":false,"x-nullable":true}]}
```